### PR TITLE
Add quantum news fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # WeeklyQuantumComputingReport
 Get your weekly news pipeline!
 
+## Scripts
+
+`scripts/fetch_news.py` uses the Google News RSS feed to find quantum related
+articles from the last seven days. It stores up to three results in
+`scripts/articles.json`.
+
 
 # TODO
 - script to Find 3 news articles each week - python?

--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -1,0 +1,52 @@
+import json
+import os
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone, timedelta
+from email.utils import parsedate_to_datetime
+
+RSS_URL = (
+    "https://news.google.com/rss/search?q=quantum&hl=en-US&gl=US&ceid=US:en"
+)
+OUTPUT_FILE = os.path.join(os.path.dirname(__file__), "articles.json")
+
+
+def fetch_articles(limit=3):
+    """Fetch quantum-related news articles from the last seven days."""
+    resp = urllib.request.urlopen(RSS_URL)
+    data = resp.read()
+    root = ET.fromstring(data)
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+    articles = []
+
+    for item in root.findall('.//item'):
+        link_elem = item.find('link')
+        pub_date_elem = item.find('pubDate')
+        if link_elem is None or pub_date_elem is None:
+            continue
+        pub_date = parsedate_to_datetime(pub_date_elem.text)
+        if pub_date >= cutoff:
+            articles.append({
+                'url': link_elem.text,
+                'title': item.findtext('title', ''),
+                'published': pub_date.isoformat(),
+            })
+        if len(articles) >= limit:
+            break
+
+    return articles
+
+
+def save_articles(articles, path=OUTPUT_FILE):
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(articles, f, indent=2)
+
+
+def main():
+    articles = fetch_articles()
+    save_articles(articles)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/fetch_news.py` to gather quantum articles from Google News RSS
- document how to use the script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635ad95a7c832db67dc1aa4c815266